### PR TITLE
keep userstream connected on screen rotation

### DIFF
--- a/Justaway/src/main/java/info/justaway/fragment/main/BaseFragment.java
+++ b/Justaway/src/main/java/info/justaway/fragment/main/BaseFragment.java
@@ -43,6 +43,12 @@ public abstract class BaseFragment extends Fragment implements
     }
 
     @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setRetainInstance(true);
+    }
+
+    @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.pull_to_refresh_list, container, false);
         if (v == null) {


### PR DESCRIPTION
BaseFragment の onCreate で setRetainInstance(true); することで、TL表示に使用するフラグメントが画面回転時にも破棄されないようにしました。

これに関連して、本来は接続完了時に更新される MainActivity#mSignalButton のテキストカラーや、
下部のタブのButton のテキストカラーを MainActivity#onSaveInstanceState と
MainActivity#onRestoreInstanceStateで保存/復元しています。

また、 MainActivity#onDestroy で無条件に破棄していた mTwitterStream について、 isFinishing() が
true の時のみ破棄するようにしています(画面回転時は破棄しない)。そのかわり、
onRetainCustomNonConfigurationInstance() で mTwitterStream を待避し、画面回転後の onCreate 呼び出しで
復元しています。これに関連して、 UserStreamListener と ConnectionLifeCycleListener も同様に待避/復元を
しています。本来は TwitterStreamのみを待避して、 UserStreamListener と ConnectionLifeCycleListener
については onCreate での復元時にセットしなおす実装が望ましいかと思いましたが、Twitter4Jに
removeListener等のAPIが無いので一度セットした Listener は外すことができないという理由により
最初にセットしたリスナーをずっと使い続けるようにしています。(ゆーすけさんに話をしたら3.1.0 で
削除用のAPI 追加してくれるとのこと)。
UserStreamListener と ConnectionLifeCycleListener は TwitterStream に握られ続けるので、元のコードのように
MainActivity の anonymous inner class だとインスタンス生成時の enclosing instance である MainActivity
インスタンス(画面回転前の物)が GC で解放されなくなるので、anonymous inner class から、 static nested 
class に変更しています。
