### PR TITLE
gradle.properties に以下のような感じの設定を書けばリリースビルドできるように設定を追加しました。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ gen/
 
 # Local configuration file (sdk path, etc)
 local.properties
+gradle.properties
 
 # Eclipse project files
 .classpath

--- a/Justaway/build.gradle
+++ b/Justaway/build.gradle
@@ -32,6 +32,26 @@ android {
         release.setRoot('build-types/release')
     }
 
+    signingConfigs {
+        // debug {
+        //     storeFile file("debug.keystore")
+        // }
+
+        release
+    }
+
+    buildTypes {
+        release {
+            runProguard false
+            proguardFile getDefaultProguardFile('proguard-android.txt')
+            proguardFile file('proguard-project.txt')
+
+            if (project.hasProperty('storeFile')) {
+                signingConfig signingConfigs.release
+            }
+        }
+    }
+
     lintOptions {
         //checkReleaseBuilds false
         abortOnError false
@@ -41,3 +61,17 @@ android {
         exclude 'META-INF/LICENSE.txt'
     }
 }
+
+if (project.hasProperty('storeFile')) {
+    android.signingConfigs.release.storeFile = file(storeFile)
+}
+if (project.hasProperty('storePassword')) {
+    android.signingConfigs.release.storePassword = storePassword
+}
+if (project.hasProperty('keyAlias')) {
+    android.signingConfigs.release.keyAlias = keyAlias
+}
+if (project.hasProperty('keyPassword')) {
+    android.signingConfigs.release.keyPassword = keyPassword
+}
+


### PR DESCRIPTION
storeFile=キーストアファイルのパス
storePassword=<キーストアのパスワード>
keyAlias=<署名用の秘密鍵のエイリアス名>
keyPassword=<秘密鍵のパスワード>

この設定をしないとリリースビルドがデバッグできなくて不便...
